### PR TITLE
python:3.9にアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.1
+FROM python:3.9
 USER root
 
 RUN apt-get update
@@ -10,10 +10,22 @@ ENV LC_ALL ja_JP.UTF-8
 ENV TZ JST-9
 ENV TERM xterm
 
-RUN apt-get install -y vim less
-# RUN apt-get install libhdf5-dev
+RUN apt-get -y update              ; \
+    apt-get -y install curl        ; \
+    apt-get -y install wget        ; \
+    apt-get -y install git         ; \
+    apt-get -y install vim         ; \
+    apt-get -y install hdf5-tools
 
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools
-RUN pip install h5py:2.7.0
-RUN pip install numpy pandas pillow
+RUN pip install numpy,             ; \
+    install pytz                   ; \
+    pip install awscli             ; \
+    pip install numcodecs          ; \
+    pip install h5py               ; \
+    pip install pandas             ; \
+    pip install pillow             ; \
+    pip install h5netcdf           ; \
+    pip install xarray             ; \
+    pip install git+https://git@github.com/HDFGroup/h5pyd


### PR DESCRIPTION
## issue
ERROR: Invalid requirement: 'h5py:2.7.0' #1

## 変更点
- pythonのバージョンを3.9に変更